### PR TITLE
Add Expiring Soon carousel tab

### DIFF
--- a/src/lib/components/CarouselCard.svelte
+++ b/src/lib/components/CarouselCard.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
   import { getApiUrl } from '$lib/config.js';
-  import { TrendingUp, Package } from 'lucide-svelte';
+  import { TrendingUp, Package, Hourglass } from 'lucide-svelte';
   
   let API_URL = '';
   let stats = [];
@@ -9,7 +9,7 @@
   let error = null;
   let interval;
   
-  // Toggle state: 'network' or 'deployed'
+  // Toggle state: 'network', 'deployed', or 'expiring'
   let viewMode = 'network';
   
   // Duplicate the array for seamless infinite scroll
@@ -29,9 +29,11 @@
   
   async function fetchCarouselStats() {
     try {
-      const endpoint = viewMode === 'network' 
+      const endpoint = viewMode === 'network'
         ? `${API_URL}/api/carousel/stats`
-        : `${API_URL}/api/carousel/deployed`;
+        : viewMode === 'deployed'
+        ? `${API_URL}/api/carousel/deployed`
+        : `${API_URL}/api/carousel/expiring`;
       
       console.log(`🎠 Fetching carousel data from: ${endpoint}`);
       
@@ -50,7 +52,11 @@
         loading = false;
         console.log(`✅ Loaded ${stats.length} carousel items`);
       } else if (stats.length === 0) {
-        error = viewMode === 'deployed' ? 'No apps deployed today' : 'No stats available';
+        error = viewMode === 'deployed'
+          ? 'No apps deployed today'
+          : viewMode === 'expiring'
+          ? 'No apps expiring within 24 hours'
+          : 'No stats available';
         loading = false;
         console.warn(`⚠️ No data available: ${error}`);
       } else {
@@ -81,6 +87,15 @@
   function formatNumber(num) {
     return new Intl.NumberFormat('en-US').format(num);
   }
+
+  function formatBlocksAsTime(blocks) {
+    const totalMinutes = Math.round(blocks * 30 / 60);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours === 0) return `${minutes}m`;
+    if (minutes === 0) return `${hours}h`;
+    return `${hours}h ${minutes}m`;
+  }
 </script>
 
 <div class="carousel-container">
@@ -88,8 +103,10 @@
     <div class="header-content">
       {#if viewMode === 'network'}
         <TrendingUp size={20} class="header-icon" />
-      {:else}
+      {:else if viewMode === 'deployed'}
         <Package size={20} class="header-icon" />
+      {:else}
+        <Hourglass size={20} class="header-icon" />
       {/if}
       
       <!-- Toggle buttons -->
@@ -101,12 +118,19 @@
         >
           Top Network Stats
         </button>
-        <button 
+        <button
           class="toggle-btn"
           class:active={viewMode === 'deployed'}
           on:click={() => toggleViewMode('deployed')}
         >
           Latest Deployed Apps
+        </button>
+        <button
+          class="toggle-btn"
+          class:active={viewMode === 'expiring'}
+          on:click={() => toggleViewMode('expiring')}
+        >
+          Expiring Soon
         </button>
       </div>
     </div>
@@ -174,7 +198,13 @@
               <span class="item-value">{stat.hdd >= 1000 ? (stat.hdd / 1000).toFixed(1) : formatNumber(stat.hdd)}</span>
               <span class="item-unit">{stat.hdd >= 1000 ? 'TB' : 'GB'} SSD</span>
             {/if}
-            
+
+            {#if stat.blocksUntilExpiry !== undefined}
+              <span class="item-separator">•</span>
+              <span class="item-value item-expiry">{formatBlocksAsTime(stat.blocksUntilExpiry)}</span>
+              <span class="item-unit">left</span>
+            {/if}
+
             <span class="item-separator">•</span>
           </div>
         {/each}
@@ -391,6 +421,11 @@
     color: var(--text-muted);
     font-size: 0.75rem;
     opacity: 0.5;
+  }
+
+  .item-expiry {
+    color: var(--accent-orange, #f97316);
+    text-shadow: 0 0 8px rgba(249, 115, 22, 0.6);
   }
   
   /* Responsive */

--- a/src/lib/services/carouselService.js
+++ b/src/lib/services/carouselService.js
@@ -6,8 +6,10 @@ import { API_ENDPOINTS } from '../config.js';
 // Cache for carousel data
 let cachedCarouselData = null;
 let cachedDeployedApps = null;
+let cachedExpiringApps = null;
 let lastFetchTime = 0;
 let lastDeployedFetchTime = 0;
+let lastExpiringFetchTime = 0;
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour cache
 
 // Images to exclude from top apps (health check/monitoring apps)
@@ -412,6 +414,91 @@ export function getCachedCarouselData() {
 }
 
 /**
+ * Fetch apps expiring within 2880 blocks (~24 hours)
+ */
+export async function fetchExpiringApps() {
+    try {
+        console.log('⏳ Fetching expiring apps...');
+
+        // Fetch current block height and app specs in parallel
+        const [blockHeightResponse, appsResponse] = await Promise.all([
+            axios.get('https://api.runonflux.io/daemon/getblockcount', { timeout: 15000 }),
+            axios.get('https://api.runonflux.io/apps/globalappsspecifications', { timeout: 15000 })
+        ]);
+
+        const currentBlockHeight = blockHeightResponse.data?.data || 0;
+        const appsData = appsResponse.data?.data || [];
+
+        if (!currentBlockHeight || !Array.isArray(appsData)) {
+            throw new Error('Invalid response from API');
+        }
+
+        console.log(`   Current block height: ${currentBlockHeight.toLocaleString()}`);
+        console.log(`   Total apps in network: ${appsData.length}`);
+
+        const BLOCKS_PER_DAY = 2880;
+        const expiringSoon = appsData
+            .filter(app => {
+                if (!app.expire) return false;
+                const expiryBlock = (app.height || 0) + app.expire;
+                const expiresInBlocks = expiryBlock - currentBlockHeight;
+                return expiresInBlocks >= 0 && expiresInBlocks < BLOCKS_PER_DAY;
+            })
+            .map(app => ({
+                ...app,
+                expiresInBlocks: (app.height || 0) + app.expire - currentBlockHeight
+            }));
+
+        console.log(`   Apps expiring within 2880 blocks: ${expiringSoon.length}`);
+
+        // Sort ascending by expiry (most urgent first)
+        expiringSoon.sort((a, b) => a.expiresInBlocks - b.expiresInBlocks);
+
+        // Format for carousel display
+        const formattedApps = expiringSoon.map((app, index) => {
+            let cpu = app.cpu || 0;
+            let ram = app.ram || 0;
+            let hdd = app.hdd || 0;
+            let instances = app.instances || 0;
+
+            if (app.compose && Array.isArray(app.compose)) {
+                cpu = app.compose.reduce((sum, c) => sum + (c.cpu || 0), 0);
+                ram = app.compose.reduce((sum, c) => sum + (c.ram || 0), 0);
+                hdd = app.compose.reduce((sum, c) => sum + (c.hdd || 0), 0);
+            }
+
+            return {
+                type: 'expiring',
+                rank: index + 1,
+                name: app.name,
+                instances: instances,
+                cpu: cpu,
+                ram: ram,
+                hdd: hdd,
+                blocksUntilExpiry: app.expiresInBlocks
+            };
+        });
+
+        cachedExpiringApps = formattedApps;
+        lastExpiringFetchTime = Date.now();
+
+        console.log('✅ Expiring apps fetched:', formattedApps.length, 'apps');
+
+        return formattedApps;
+
+    } catch (error) {
+        console.error('❌ Error fetching expiring apps:', error.message);
+
+        if (cachedExpiringApps) {
+            console.log('⚠️ Using cached expiring apps data due to fetch error');
+            return cachedExpiringApps;
+        }
+
+        return [];
+    }
+}
+
+/**
  * Get cached deployed apps data (used by API endpoint)
  * If no cache exists, fetch immediately
  */
@@ -432,6 +519,31 @@ export async function getCachedDeployedApps() {
     return {
         stats: cachedDeployedApps || [],
         cached: !!cachedDeployedApps,
+        cacheAge: Math.floor(cacheAge / 1000), // seconds
+        fresh: isFresh
+    };
+}
+
+/**
+ * Get cached expiring apps data (used by API endpoint)
+ * If no cache exists, fetch immediately
+ */
+export async function getCachedExpiringApps() {
+    const cacheAge = Date.now() - lastExpiringFetchTime;
+    const isFresh = cacheAge < CACHE_DURATION;
+
+    if (!cachedExpiringApps || !isFresh) {
+        console.log('⏳ No fresh expiring apps cache, fetching now...');
+        try {
+            await fetchExpiringApps();
+        } catch (error) {
+            console.error('❌ Failed to fetch expiring apps on-demand:', error);
+        }
+    }
+
+    return {
+        stats: cachedExpiringApps || [],
+        cached: !!cachedExpiringApps,
         cacheAge: Math.floor(cacheAge / 1000), // seconds
         fresh: isFresh
     };

--- a/src/server.js
+++ b/src/server.js
@@ -49,7 +49,7 @@ import { testAllServices } from './lib/services/test-allServices.js';
 import { backfillRevenueSnapshots } from './lib/db/run-backfill.js';
 
 import { json } from '@sveltejs/kit';
-import { getCachedCarouselData, getCachedDeployedApps } from './lib/services/carouselService.js';
+import { getCachedCarouselData, getCachedDeployedApps, getCachedExpiringApps } from './lib/services/carouselService.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -1046,6 +1046,23 @@ app.get('/api/carousel/deployed', async (req, res) => {
             stats: [],
             cached: false
         });
+    }
+});
+
+// Carousel endpoint for expiring soon apps
+app.get('/api/carousel/expiring', async (req, res) => {
+    try {
+        const result = await getCachedExpiringApps();
+        res.json({
+            stats: result.stats || [],
+            cached: result.cached,
+            cacheAge: result.cacheAge,
+            fresh: result.fresh,
+            timestamp: new Date().toISOString()
+        });
+    } catch (error) {
+        console.error('❌ Error in expiring apps API:', error);
+        res.status(500).json({ error: 'Failed to fetch expiring apps', message: error.message, stats: [], cached: false });
     }
 });
 


### PR DESCRIPTION
## Summary
- Adds a third tab to the dashboard carousel: **Expiring Soon**
- Shows Flux apps expiring within the next 2880 blocks (~24 hours)
- Expiry calculation matches the Fluxnode implementation: `spec.height + spec.expire - currentBlock`
- Sorted by soonest expiry first, displayed as `Xh Ym left` (e.g. `23h 30m left`) using 30s/block
- Hourglass icon and orange accent colour to convey urgency
- New `/api/carousel/expiring` endpoint with 1-hour cache (mirrors `/api/carousel/deployed`)

## Test plan
- [x] Three buttons appear: **Top Network Stats** | **Latest Deployed Apps** | **Expiring Soon**
- [x] Clicking **Expiring Soon** shows the Hourglass icon and loads the carousel
- [x] Each app shows time remaining in `Xh Ym left` format in orange
- [x] If no apps are expiring within 24 hours, shows "No apps expiring within 24 hours"
- [x] `GET /api/carousel/expiring` returns valid JSON with `stats` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)