### PR TITLE
fix: Docker race condition, shared API cache, pagination cap, failedTxids cleanup

### DIFF
--- a/src/lib/services/carouselService.js
+++ b/src/lib/services/carouselService.js
@@ -12,6 +12,11 @@ let lastDeployedFetchTime = 0;
 let lastExpiringFetchTime = 0;
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour cache
 
+// Shared cache for expensive Flux API calls (block height + app specs)
+let cachedFluxApiData = null;
+let lastFluxApiCacheTime = 0;
+const FLUX_API_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
 // Images to exclude from top apps (health check/monitoring apps)
 const EXCLUDED_IMAGES = [
     'containrrr/watchtower',  // Health check image on all servers
@@ -62,20 +67,34 @@ export async function fetchCarouselData() {
 }
 
 /**
+ * Shared fetch for block height + app specs with short-lived cache.
+ * Prevents duplicate API calls when multiple carousel tabs load in quick succession.
+ */
+async function getSharedFluxApiData() {
+    const age = Date.now() - lastFluxApiCacheTime;
+    if (cachedFluxApiData && age < FLUX_API_CACHE_DURATION) {
+        return cachedFluxApiData;
+    }
+    const [blockHeightResponse, appsResponse] = await Promise.all([
+        axios.get('https://api.runonflux.io/daemon/getblockcount', { timeout: 15000 }),
+        axios.get('https://api.runonflux.io/apps/globalappsspecifications', { timeout: 15000 })
+    ]);
+    cachedFluxApiData = {
+        currentBlockHeight: blockHeightResponse.data?.data || 0,
+        appsData: appsResponse.data?.data || []
+    };
+    lastFluxApiCacheTime = Date.now();
+    return cachedFluxApiData;
+}
+
+/**
  * Fetch latest deployed apps (deployed today)
  */
 export async function fetchLatestDeployedApps() {
     try {
         console.log('📦 Fetching latest deployed apps...');
-        
-        // Fetch current block height and app specs in parallel
-        const [blockHeightResponse, appsResponse] = await Promise.all([
-            axios.get('https://api.runonflux.io/daemon/getblockcount', { timeout: 15000 }),
-            axios.get('https://api.runonflux.io/apps/globalappsspecifications', { timeout: 15000 })
-        ]);
-        
-        const currentBlockHeight = blockHeightResponse.data?.data || 0;
-        const appsData = appsResponse.data?.data || [];
+
+        const { currentBlockHeight, appsData } = await getSharedFluxApiData();
         
         if (!currentBlockHeight || !Array.isArray(appsData)) {
             throw new Error('Invalid response from API');
@@ -420,14 +439,7 @@ export async function fetchExpiringApps() {
     try {
         console.log('⏳ Fetching expiring apps...');
 
-        // Fetch current block height and app specs in parallel
-        const [blockHeightResponse, appsResponse] = await Promise.all([
-            axios.get('https://api.runonflux.io/daemon/getblockcount', { timeout: 15000 }),
-            axios.get('https://api.runonflux.io/apps/globalappsspecifications', { timeout: 15000 })
-        ]);
-
-        const currentBlockHeight = blockHeightResponse.data?.data || 0;
-        const appsData = appsResponse.data?.data || [];
+        const { currentBlockHeight, appsData } = await getSharedFluxApiData();
 
         if (!currentBlockHeight || !Array.isArray(appsData)) {
             throw new Error('Invalid response from API');

--- a/src/lib/services/revenueService.js
+++ b/src/lib/services/revenueService.js
@@ -114,8 +114,9 @@ export function getFailedTxStats() {
  */
 export function clearPermanentlyFailedTxids() {
     let cleared = 0;
+    const sevenDaysAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
     failedTxids.forEach((data, txid) => {
-        if (data.attempts >= 5) {
+        if (data.attempts >= 5 || data.lastAttempt < sevenDaysAgo) {
             failedTxids.delete(txid);
             cleared++;
         }

--- a/src/server.js
+++ b/src/server.js
@@ -31,14 +31,15 @@ import {
 } from './lib/services/revenueScheduler.js';
 
 // Import revenue service for manual trigger
-import { 
+import {
     fetchRevenueStats,
     calculateMonthlyRevenue,
     calculatePreviousMonthRevenue,
     getMonthlyPaymentCount,
     getPreviousMonthPaymentCount,
     calculateYesterdayRevenue,
-    getYesterdayPaymentCount
+    getYesterdayPaymentCount,
+    clearPermanentlyFailedTxids
 } from './lib/services/revenueService.js';
 
 // Import testAllServices
@@ -666,8 +667,8 @@ app.get('/api/transactions/summary', (req, res) => {
 app.get('/api/transactions/paginated', (req, res) => {
     try {
         console.log('Starting transaction pagination');
-        const page = parseInt(req.query.page) || 1;
-        const limit = parseInt(req.query.limit) || 50;
+        const page = Math.max(parseInt(req.query.page) || 1, 1);
+        const limit = Math.min(Math.max(parseInt(req.query.limit) || 50, 1), 500);
         const search = req.query.search || '';
         
         const result = getTransactionsPaginated(page, limit, search);
@@ -1120,7 +1121,13 @@ app.listen(PORT, '0.0.0.0', () => {
         console.error('❌ Could not initialize snapshot checker:', error.message);
         console.error('⚠️  System will continue but snapshots may not be taken!');
     }
-    
+
+    // Run failed txid cleanup daily
+    setInterval(() => {
+        const cleared = clearPermanentlyFailedTxids();
+        if (cleared > 0) console.log(`🧹 Cleared ${cleared} permanently failed txids`);
+    }, 24 * 60 * 60 * 1000);
+
     console.log('\n🎉 All services started successfully!');
     console.log('──────────────────────────────────────────────────\n');
     
@@ -1138,23 +1145,13 @@ app.listen(PORT, '0.0.0.0', () => {
 // Graceful shutdown
 process.on('SIGTERM', () => {
     console.log('🛑 SIGTERM received, shutting down gracefully...');
+    stopCarouselUpdates();
     process.exit(0);
 });
 
 process.on('SIGINT', () => {
     console.log('🛑 SIGINT received, shutting down gracefully...');
-    process.exit(0);
-});
-
-process.on('SIGTERM', () => {
-    console.log('🛑 SIGTERM received, shutting down gracefully...');
-    stopCarouselUpdates();  
-    process.exit(0);
-});
-
-process.on('SIGINT', () => {
-    console.log('🛑 SIGINT received, shutting down gracefully...');
-    stopCarouselUpdates();  
+    stopCarouselUpdates();
     process.exit(0);
 });
 

--- a/startup.sh
+++ b/startup.sh
@@ -14,17 +14,24 @@ echo "📡 Starting API server on port ${API_PORT:-3000}..."
 PORT=${API_PORT:-3000} node src/server.js &
 API_PID=$!
 
-# Give the API server a moment to start
-sleep 3
+# Wait for the API server to be ready
+echo "⏳ Waiting for API server to be ready..."
+RETRIES=30
+until curl -sf http://127.0.0.1:${API_PORT:-3000}/api/health > /dev/null 2>&1; do
+    RETRIES=$((RETRIES - 1))
+    if [ $RETRIES -eq 0 ]; then
+        echo "❌ API server failed to start within 30 seconds. Exiting."
+        exit 1
+    fi
+    sleep 1
+done
+echo "✅ API server is ready."
 
 # Start the SvelteKit frontend (using the built app)
 echo "🎨 Starting frontend on port ${FRONTEND_PORT:-5173}..."
 # Set PORT environment variable for SvelteKit
 PORT=${FRONTEND_PORT:-5173} HOST=${HOST:-0.0.0.0} node build/index.js &
 FRONTEND_PID=$!
-
-# Give frontend a moment to start
-sleep 2
 
 echo "✅ Both services started successfully!"
 echo "   API: http://localhost:${API_PORT:-3000}"


### PR DESCRIPTION
## Summary

- **Docker startup fix** (`startup.sh`): Replace blind `sleep 3` + `sleep 2` with a `curl` health-check loop that polls `/api/health` up to 30 times (1 attempt/sec). Frontend only starts once the Express server is confirmed ready — eliminates 503s on first load in slow-start containers.
- **Shared Flux API cache** (`carouselService.js`): `fetchLatestDeployedApps` and `fetchExpiringApps` previously made independent calls to `getblockcount` + `globalappsspecifications`. A new `getSharedFluxApiData()` with a 5-minute cache means at most one fetch per 5 minutes regardless of how many carousel tabs load back-to-back.
- **Pagination cap** (`server.js`): `page` clamped to `≥ 1`; `limit` clamped to `[1, 500]`. Prevents unbounded DB queries via `?limit=99999`.
- **`failedTxids` memory leak** (`revenueService.js` + `server.js`): Extended `clearPermanentlyFailedTxids()` to also evict entries not retried in 7+ days (stale txids from old sync cycles). Added a daily `setInterval` in `server.js` to actually call it — it was exported but never invoked.
- **Duplicate signal handlers** (`server.js`): Removed the first SIGTERM/SIGINT pair that called `process.exit(0)` without `stopCarouselUpdates()`. Kept only the correct handlers.

## Test plan

- [x] `docker build -t fluxtracker . && docker run -p 3000:3000 -p 5173:5173 fluxtracker` — container logs show `✅ API server is ready.` before frontend starts; no 503 on first load
- [x] Click "Latest Deployed" then "Expiring Soon" back-to-back — server logs show only **one** `globalappsspecifications` fetch
- [x] `curl "http://localhost:3000/api/transactions/paginated?limit=99999"` — response returns ≤ 500 rows
- [x] After revenue sync cycles, `GET /api/admin/revenue-status` shows `failedTxids` count stays bounded
- [x] `kill -SIGTERM <pid>` — logs show `stopCarouselUpdates` called exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)