### PR TITLE
feat: filter app-management txs + Enterprise badge in carousels

### DIFF
--- a/src/lib/components/CarouselCard.svelte
+++ b/src/lib/components/CarouselCard.svelte
@@ -182,21 +182,26 @@
               <span class="item-separator">•</span>
             {/if}
             
-            {#if stat.cpu !== undefined}
-              <span class="item-value">{stat.cpu >= 1 ? formatNumber(stat.cpu) : (Math.round(stat.cpu * 100) / 100)}</span>
-              <span class="item-unit">{stat.cpu >= 1 ? (stat.cpu === 1 ? 'core' : 'cores') : 'threads'}</span>
+            {#if stat.isEnterprise}
               <span class="item-separator">•</span>
-            {/if}
-            
-            {#if stat.ram !== undefined}
-              <span class="item-value">{stat.ram >= 1000 ? (stat.ram / 1000).toFixed(1) : formatNumber(stat.ram)}</span>
-              <span class="item-unit">{stat.ram >= 1000 ? 'GB' : 'MB'} RAM</span>
-              <span class="item-separator">•</span>
-            {/if}
-            
-            {#if stat.hdd !== undefined}
-              <span class="item-value">{stat.hdd >= 1000 ? (stat.hdd / 1000).toFixed(1) : formatNumber(stat.hdd)}</span>
-              <span class="item-unit">{stat.hdd >= 1000 ? 'TB' : 'GB'} SSD</span>
+              <span class="item-badge item-enterprise">Enterprise</span>
+            {:else}
+              {#if stat.cpu !== undefined}
+                <span class="item-value">{stat.cpu >= 1 ? formatNumber(stat.cpu) : (Math.round(stat.cpu * 100) / 100)}</span>
+                <span class="item-unit">{stat.cpu >= 1 ? (stat.cpu === 1 ? 'core' : 'cores') : 'threads'}</span>
+                <span class="item-separator">•</span>
+              {/if}
+
+              {#if stat.ram !== undefined}
+                <span class="item-value">{stat.ram >= 1000 ? (stat.ram / 1000).toFixed(1) : formatNumber(stat.ram)}</span>
+                <span class="item-unit">{stat.ram >= 1000 ? 'GB' : 'MB'} RAM</span>
+                <span class="item-separator">•</span>
+              {/if}
+
+              {#if stat.hdd !== undefined}
+                <span class="item-value">{stat.hdd >= 1000 ? (stat.hdd / 1000).toFixed(1) : formatNumber(stat.hdd)}</span>
+                <span class="item-unit">{stat.hdd >= 1000 ? 'TB' : 'GB'} SSD</span>
+              {/if}
             {/if}
 
             {#if stat.blocksUntilExpiry !== undefined}
@@ -426,6 +431,24 @@
   .item-expiry {
     color: var(--accent-orange, #f97316);
     text-shadow: 0 0 8px rgba(249, 115, 22, 0.6);
+  }
+
+  .item-badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 0.2rem 0.6rem;
+    border-radius: var(--radius-sm, 4px);
+    border: 1px solid;
+    flex-shrink: 0;
+  }
+
+  .item-enterprise {
+    color: var(--accent-purple, #a855f7);
+    border-color: var(--accent-purple, #a855f7);
+    background: rgba(168, 85, 247, 0.12);
+    box-shadow: 0 0 8px rgba(168, 85, 247, 0.2), inset 0 0 8px rgba(168, 85, 247, 0.05);
   }
   
   /* Responsive */

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -206,6 +206,16 @@ export const WORDPRESS_CONFIG = {
 };
 
 // ============================================
+// EXCLUDED TRANSACTION PATTERNS
+// ============================================
+export const EXCLUDED_TRANSACTIONS = [
+    {
+        from_address: 't1Mzja9iJcEYeW5B4m4s1tJG8M42odFZ16A',
+        amount: 0.02  // FLUX (app spec-change fee – treated as free for end user)
+    }
+];
+
+// ============================================
 // REVENUE CALCULATION CONFIG
 // ============================================
 export const REVENUE_CONFIG = {

--- a/src/lib/services/carouselService.js
+++ b/src/lib/services/carouselService.js
@@ -126,14 +126,16 @@ export async function fetchLatestDeployedApps() {
             let ram = app.ram || 0;
             let hdd = app.hdd || 0;
             let instances = app.instances || 0;
-            
+
             // If app has compose array, sum up resources from all containers
             if (app.compose && Array.isArray(app.compose)) {
                 cpu = app.compose.reduce((sum, c) => sum + (c.cpu || 0), 0);
                 ram = app.compose.reduce((sum, c) => sum + (c.ram || 0), 0);
                 hdd = app.compose.reduce((sum, c) => sum + (c.hdd || 0), 0);
             }
-            
+
+            const isEnterprise = !!(app.enterprise);
+
             // Format the details string
             const details = [
                 `${instances} ${instances === 1 ? 'instance' : 'instances'}`,
@@ -141,7 +143,7 @@ export async function fetchLatestDeployedApps() {
                 `${formatRam(ram)}`,
                 `${formatStorage(hdd)}`
             ].join(' • ');
-            
+
             return {
                 type: 'deployed',
                 rank: index + 1,
@@ -152,6 +154,7 @@ export async function fetchLatestDeployedApps() {
                 cpu: cpu,
                 ram: ram,
                 hdd: hdd,
+                isEnterprise: isEnterprise,
                 height: app.height,
                 blockAge: currentBlockHeight - app.height
             };
@@ -479,6 +482,8 @@ export async function fetchExpiringApps() {
                 hdd = app.compose.reduce((sum, c) => sum + (c.hdd || 0), 0);
             }
 
+            const isEnterprise = !!(app.enterprise);
+
             return {
                 type: 'expiring',
                 rank: index + 1,
@@ -487,6 +492,7 @@ export async function fetchExpiringApps() {
                 cpu: cpu,
                 ram: ram,
                 hdd: hdd,
+                isEnterprise: isEnterprise,
                 blocksUntilExpiry: app.expiresInBlocks
             };
         });

--- a/src/lib/services/revenueService.js
+++ b/src/lib/services/revenueService.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { API_ENDPOINTS, TARGET_ADDRESSES, BLOCK_CONFIG } from '../config.js';
+import { API_ENDPOINTS, TARGET_ADDRESSES, BLOCK_CONFIG, EXCLUDED_TRANSACTIONS } from '../config.js';
 import { 
     updateCurrentMetrics, 
     updateSyncStatus,
@@ -339,10 +339,16 @@ function processTransaction(tx, trackedAddresses, fluxPriceUSD = null) {
             if (trackedAddresses.includes(address)) {
                 const amountSatoshis = parseFloat(vout.value) || 0;
                 const amountFlux = amountSatoshis / 100000000;
-                
+
+                // Skip excluded transactions (e.g. Flux app spec-change fees)
+                const isExcluded = EXCLUDED_TRANSACTIONS.some(
+                    ex => ex.from_address === fromAddress && Math.abs(ex.amount - amountFlux) < 0.000001
+                );
+                if (isExcluded) continue;
+
                 // Calculate USD value if price is available
                 const amountUSD = fluxPriceUSD ? amountFlux * fluxPriceUSD : null;
-                
+
                 transactions.push({
                     txid: tx.txid,
                     address: address,


### PR DESCRIPTION
## Summary

- **Revenue filter**: Skip 0.02 FLUX app spec-change fees (from `t1Mzja9iJcEYeW5B4m4s1tJG8M42odFZ16A`) during transaction sync — these are infrastructure fees, not real revenue. Existing DB rows are unaffected.
- **Enterprise badge**: Carousel cards for Latest Deployed Apps and Expiring Soon now detect `app.enterprise` from the Flux API and render a styled purple pill badge labelled `ENTERPRISE` instead of the misleading zero CPU/RAM/HDD values.

## Files changed

| File | Change |
|------|--------|
| `src/lib/config.js` | Added `EXCLUDED_TRANSACTIONS` constant |
| `src/lib/services/revenueService.js` | Import + apply exclusion filter in `processTransaction()` |
| `src/lib/services/carouselService.js` | Add `isEnterprise` to deployed + expiring formatters |
| `src/lib/components/CarouselCard.svelte` | Conditional Enterprise badge rendering + CSS pill style |

## Test plan

- [x] Watch console during a sync cycle — transactions from the excluded address with 0.02 FLUX should be silently skipped
- [x] Open Latest Deployed Apps or Expiring Soon carousel and confirm Enterprise apps show the `ENTERPRISE` pill badge instead of zero resource values
- [x] Confirm normal apps still show CPU/RAM/HDD as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)