### PR TITLE
fix: bypass canWrite() guard in resetRevenueSyncBlock

### DIFF
--- a/src/lib/db/database.js
+++ b/src/lib/db/database.js
@@ -1007,7 +1007,7 @@ export function updateSyncStatus(syncType, status, errorMessage = null, lastBloc
 }
 
 export function resetRevenueSyncBlock() {
-    if (!canWrite()) return;
+    // Admin operation — bypass canWrite() so it always executes regardless of writer election
     db.prepare('UPDATE sync_status SET last_sync_block = NULL WHERE sync_type = ?').run('revenue');
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -204,8 +204,16 @@ app.post('/api/admin/revenue-sync', async (req, res) => {
 app.post('/api/admin/reset-revenue-sync', (req, res) => {
     try {
         resetRevenueSyncBlock();
-        console.log('🔄 Revenue sync block reset — full history scan will run on next cycle');
-        res.json({ success: true, message: 'Revenue sync block reset. Full history scan from block 0 will run on next sync cycle.' });
+        const verified = getSyncStatus('revenue');
+        const didReset = verified?.last_sync_block === null;
+        console.log(`🔄 Revenue sync block reset — last_sync_block is now ${verified?.last_sync_block}`);
+        res.json({
+            success: didReset,
+            last_sync_block: verified?.last_sync_block ?? null,
+            message: didReset
+                ? 'Reset successful. Full history scan from block 0 will run on next sync cycle.'
+                : 'Reset may not have applied — last_sync_block is still set.'
+        });
     } catch (error) {
         res.status(500).json({ error: error.message });
     }


### PR DESCRIPTION
## Summary

- `resetRevenueSyncBlock()` was silently skipping the DB update due to the `canWrite()` guard, causing the reset endpoint to return success even when nothing was updated
- Removed the guard — admin resets must always execute regardless of writer election
- Endpoint now verifies and returns the actual `last_sync_block` value after reset so you can confirm it applied

## Test plan

- [x] `POST /api/admin/reset-revenue-sync` returns `{ "success": true, "last_sync_block": null }`
- [x] Next sync cycle logs `Block range: 0 -> ...` confirming full history scan from genesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)