### PR TITLE
fix: add missing getSyncStatus import to server.js

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -16,7 +16,8 @@ import {
     getDailyRevenueInRange,
     getDailyRevenueUSDFromTransactions,
     getDailyRevenueUSDInRange,
-    resetRevenueSyncBlock
+    resetRevenueSyncBlock,
+    getSyncStatus
 } from './lib/db/database.js';
 
 // Import the NEW snapshot manager


### PR DESCRIPTION
## Summary

- `getSyncStatus` was used in the `reset-revenue-sync` endpoint but not imported, causing a runtime error

## Test plan

- [ ] `POST /api/admin/reset-revenue-sync` returns `{ "success": true, "last_sync_block": null }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)