### PR TITLE
Add price history to R2 backups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,13 @@
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+
+# Optional: Failover Supabase instance (auto-switch when primary is unreachable)
+SUPABASE_FAILOVER_URL=
+SUPABASE_FAILOVER_KEY=
+
+# Optional: Cloudflare R2 backup (all 4 required to enable backups)
+R2_ENDPOINT=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=

--- a/src/lib/db/database.js
+++ b/src/lib/db/database.js
@@ -1330,6 +1330,35 @@ export async function recategorizeAllRepos() {
 // BACKUP EXPORT / IMPORT
 // ============================================
 
+export async function exportAllPriceHistory() {
+    const { data, error } = await supabase
+        .from('flux_price_history')
+        .select('*')
+        .order('date', { ascending: true });
+
+    if (error) throw new Error(`Export flux_price_history failed: ${error.message}`);
+    return data || [];
+}
+
+export async function upsertPriceHistory(rows) {
+    if (!rows || rows.length === 0) return 0;
+
+    const CHUNK_SIZE = 500;
+    let total = 0;
+
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+        const chunk = rows.slice(i, i + CHUNK_SIZE);
+        const { error } = await supabase
+            .from('flux_price_history')
+            .upsert(chunk, { onConflict: 'date' });
+
+        if (error) throw new Error(`Upsert flux_price_history chunk ${i} failed: ${error.message}`);
+        total += chunk.length;
+    }
+
+    return total;
+}
+
 export async function exportAllDailySnapshots() {
     const { data, error } = await supabase
         .from('daily_snapshots')

--- a/src/lib/db/snapshotManager.js
+++ b/src/lib/db/snapshotManager.js
@@ -251,7 +251,7 @@ async function takeSnapshot() {
         // Fire-and-forget backup after successful snapshot
         if (isBackupEnabled()) {
             performBackup().then(result => {
-                if (result.success) console.log(`Backup: ${result.tables.daily_snapshots} daily + ${result.tables.repo_snapshots} repo rows`);
+                if (result.success) console.log(`Backup: ${result.tables.daily_snapshots} daily + ${result.tables.repo_snapshots} repo + ${result.tables.flux_price_history} price rows`);
                 else console.warn(`Backup failed: ${result.error}`);
             }).catch(err => console.warn(`Backup error: ${err.message}`));
         }

--- a/src/lib/services/backupService.js
+++ b/src/lib/services/backupService.js
@@ -19,8 +19,10 @@ import {
 import {
     exportAllDailySnapshots,
     exportAllRepoSnapshots,
+    exportAllPriceHistory,
     upsertDailySnapshots,
-    upsertRepoSnapshots
+    upsertRepoSnapshots,
+    upsertPriceHistory
 } from '../db/database.js';
 
 // ============================================
@@ -118,6 +120,9 @@ export async function performBackup() {
         console.log('Backup: exporting repo_snapshots...');
         const repoRows = await exportAllRepoSnapshots();
 
+        console.log('Backup: exporting flux_price_history...');
+        const priceRows = await exportAllPriceHistory();
+
         // Upload daily_snapshots
         const dailyPayload = JSON.stringify({
             table: 'daily_snapshots',
@@ -148,6 +153,21 @@ export async function performBackup() {
             ContentType: 'application/json'
         }));
 
+        // Upload flux_price_history
+        const pricePayload = JSON.stringify({
+            table: 'flux_price_history',
+            exportedAt: now,
+            rowCount: priceRows.length,
+            rows: priceRows
+        });
+
+        await client.send(new PutObjectCommand({
+            Bucket: bucket,
+            Key: `backups/${dateStr}/flux_price_history.json`,
+            Body: pricePayload,
+            ContentType: 'application/json'
+        }));
+
         // Prune old backups
         const pruned = await pruneOldBackups(client, bucket);
 
@@ -161,7 +181,8 @@ export async function performBackup() {
             date: dateStr,
             tables: {
                 daily_snapshots: dailyRows.length,
-                repo_snapshots: repoRows.length
+                repo_snapshots: repoRows.length,
+                flux_price_history: priceRows.length
             },
             pruned
         };
@@ -233,6 +254,19 @@ export async function restoreFromBackup(date) {
         }));
         const repoJson = JSON.parse(await repoObj.Body.transformToString());
 
+        // Download flux_price_history (optional — older backups may not have it)
+        let priceJson = null;
+        try {
+            console.log(`Restore: downloading flux_price_history from ${date}...`);
+            const priceObj = await client.send(new GetObjectCommand({
+                Bucket: bucket,
+                Key: `backups/${date}/flux_price_history.json`
+            }));
+            priceJson = JSON.parse(await priceObj.Body.transformToString());
+        } catch {
+            console.log('Restore: no price history backup found (skipping)');
+        }
+
         // Upsert into DB
         console.log(`Restore: upserting ${dailyJson.rowCount} daily snapshots...`);
         const dailyCount = await upsertDailySnapshots(dailyJson.rows);
@@ -240,12 +274,19 @@ export async function restoreFromBackup(date) {
         console.log(`Restore: upserting ${repoJson.rowCount} repo snapshots...`);
         const repoCount = await upsertRepoSnapshots(repoJson.rows);
 
+        let priceCount = 0;
+        if (priceJson) {
+            console.log(`Restore: upserting ${priceJson.rowCount} price history rows...`);
+            priceCount = await upsertPriceHistory(priceJson.rows);
+        }
+
         return {
             success: true,
             date,
             restored: {
                 daily_snapshots: dailyCount,
-                repo_snapshots: repoCount
+                repo_snapshots: repoCount,
+                flux_price_history: priceCount
             }
         };
 


### PR DESCRIPTION
## Summary
- Add `flux_price_history` table to automated R2 backups alongside daily_snapshots and repo_snapshots
- Add `exportAllPriceHistory()` and `upsertPriceHistory()` database functions
- Restore gracefully skips price history if backup predates this change
- Update `.env.example` with R2 and failover env var placeholders

## Test plan
- [x] `POST /api/admin/backup` returns `flux_price_history` count in response
- [x] Verified backup file appears in R2 bucket
- [x] `POST /api/admin/restore` restores all 3 tables
- [x] Restore from older backups (without price file) works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)