### PR TITLE
refactor: centralize hardcoded constants in config.js

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -293,6 +293,46 @@ export const PERFORMANCE_CONFIG = {
 };
 
 // ============================================
+// REVENUE SYNC TUNING
+// ============================================
+export const REVENUE_SYNC = {
+    TXID_CHUNK_SIZE: 50000,         // Blocks per API call — conservative to avoid public API timeouts
+    DB_FLUSH_SIZE: 200,             // Write to DB every N payments so graphs update progressively
+    APP_NAME_BATCH_SIZE: 10,        // Concurrent app-name lookups per batch
+    AUDIT_LOOKBACK_BLOCKS: 4320,    // ~3 days of blocks for audit re-scan
+    AUDIT_BATCH_SIZE: 10,           // Concurrent fetches during audit retry
+    PRICE_HISTORY_BATCH_SIZE: 1000, // Rows per insert batch for price history backfill
+};
+
+// ============================================
+// SNAPSHOT TUNING
+// ============================================
+export const SNAPSHOT_CONFIG = {
+    CHECK_INTERVAL_MS: 30 * 60 * 1000,  // Check every 30 minutes
+    GRACE_PERIOD_MINUTES: 5,             // Wait 5 minutes after midnight before snapshotting
+    MIN_VALID_METRICS: 2,                // Minimum non-zero key metrics required
+    MAX_METRIC_AGE_HOURS: 24,            // Accept metrics up to this many hours old
+    MAX_REPO_RETRIES: 5,                 // Max retries for missing repo snapshot data
+};
+
+// ============================================
+// BACKUP TUNING
+// ============================================
+export const BACKUP_CONFIG = {
+    RETENTION_DAYS: 30,              // Keep backups for this many days
+    UPLOAD_MAX_RETRIES: 3,           // Retry failed S3 uploads this many times
+    UPLOAD_INITIAL_BACKOFF_MS: 1000, // First retry delay (quadrupled each retry: 1s, 4s, 16s)
+};
+
+// ============================================
+// CIRCUIT BREAKER TUNING
+// ============================================
+export const CIRCUIT_BREAKER_CONFIG = {
+    FAILURE_THRESHOLD: 5,   // Consecutive failures before tripping to OPEN
+    COOLDOWN_MS: 60_000,    // Time in OPEN before probing (HALF_OPEN)
+};
+
+// ============================================
 // HELPER FUNCTIONS
 // ============================================
 

--- a/src/lib/db/circuitBreaker.js
+++ b/src/lib/db/circuitBreaker.js
@@ -5,11 +5,12 @@
 // In SQLite mode the DB is local — circuit breaker is always CLOSED.
 
 import { switchToFailover, hasFailover } from './supabaseClient.js';
+import { CIRCUIT_BREAKER_CONFIG } from '../config.js';
 
 const isSqlite = (process.env.DB_TYPE || 'supabase').toLowerCase() === 'sqlite';
 
-const FAILURE_THRESHOLD = 5;
-const COOLDOWN_MS = 60_000; // 60 seconds
+const FAILURE_THRESHOLD = CIRCUIT_BREAKER_CONFIG.FAILURE_THRESHOLD;
+const COOLDOWN_MS = CIRCUIT_BREAKER_CONFIG.COOLDOWN_MS;
 
 let state = 'CLOSED';
 let failureCount = 0;

--- a/src/lib/db/snapshotManager.js
+++ b/src/lib/db/snapshotManager.js
@@ -15,16 +15,17 @@ import {
 import { getLatestRepoCounts } from '../services/cloudService.js';
 import { shouldAllowRequest, recordSuccess, recordFailure } from './circuitBreaker.js';
 import { isBackupEnabled, performBackup } from '../services/backupService.js';
+import { SNAPSHOT_CONFIG as SNAP_CFG } from '../config.js';
 
 // ============================================
 // CONFIGURATION
 // ============================================
 
 const CONFIG = {
-    CHECK_INTERVAL_MS: 30 * 60 * 1000,  // Check every 30 minutes
-    GRACE_PERIOD_MINUTES: 5,             // Wait 5 minutes after midnight
-    MIN_VALID_METRICS: 2,                // Only need 2 metrics populated
-    MAX_METRIC_AGE_HOURS: 24,            // Accept metrics up to 24 hours old
+    CHECK_INTERVAL_MS: SNAP_CFG.CHECK_INTERVAL_MS,
+    GRACE_PERIOD_MINUTES: SNAP_CFG.GRACE_PERIOD_MINUTES,
+    MIN_VALID_METRICS: SNAP_CFG.MIN_VALID_METRICS,
+    MAX_METRIC_AGE_HOURS: SNAP_CFG.MAX_METRIC_AGE_HOURS,
 };
 
 let state = {
@@ -277,7 +278,7 @@ async function takeSnapshot() {
 // MAIN CHECK
 // ============================================
 
-const MAX_REPO_RETRIES = 5;
+const MAX_REPO_RETRIES = SNAP_CFG.MAX_REPO_RETRIES;
 
 function scheduleRepoRetry(source) {
     if (state.repoRetryCount >= MAX_REPO_RETRIES) {

--- a/src/lib/services/backupService.js
+++ b/src/lib/services/backupService.js
@@ -24,14 +24,15 @@ import {
     upsertRepoSnapshots,
     upsertPriceHistory
 } from '../db/database.js';
+import { BACKUP_CONFIG } from '../config.js';
 
 // ============================================
 // CONFIGURATION
 // ============================================
 
-const RETENTION_DAYS = 30;
-const UPLOAD_MAX_RETRIES = 3;
-const UPLOAD_INITIAL_BACKOFF_MS = 1000; // 1s, 4s, 16s (quadrupled each retry)
+const RETENTION_DAYS = BACKUP_CONFIG.RETENTION_DAYS;
+const UPLOAD_MAX_RETRIES = BACKUP_CONFIG.UPLOAD_MAX_RETRIES;
+const UPLOAD_INITIAL_BACKOFF_MS = BACKUP_CONFIG.UPLOAD_INITIAL_BACKOFF_MS;
 
 function getConfig() {
     return {

--- a/src/lib/services/priceHistoryService.js
+++ b/src/lib/services/priceHistoryService.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { API_ENDPOINTS } from '../config.js';
+import { API_ENDPOINTS, REVENUE_SYNC } from '../config.js';
 import {
     insertPriceHistoryBatch,
     getLatestPriceDate,
@@ -143,11 +143,11 @@ export async function backfillNullUsdAmounts() {
     let updated = 0;
     let skipped = 0;
     const missingPriceDates = new Set();
-    const BATCH_SIZE = 1000;
+    const batchSize = REVENUE_SYNC.PRICE_HISTORY_BATCH_SIZE;
 
     // Process in batches to avoid loading all NULL transactions at once
     while (true) {
-        const txs = await getTransactionsWithNullUsd(BATCH_SIZE);
+        const txs = await getTransactionsWithNullUsd(batchSize);
         if (txs.length === 0) break;
 
         const updates = [];

--- a/src/lib/services/revenueService.js
+++ b/src/lib/services/revenueService.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { API_ENDPOINTS, TARGET_ADDRESSES, EXCLUDED_TRANSACTIONS } from '../config.js';
+import { API_ENDPOINTS, TARGET_ADDRESSES, EXCLUDED_TRANSACTIONS, REVENUE_SYNC } from '../config.js';
 import {
     updateCurrentMetrics,
     updateSyncStatus,
@@ -188,7 +188,7 @@ export async function fetchCurrentBlockHeight() {
     }
 }
 
-const TXID_CHUNK_SIZE = 50000; // blocks per API call — conservative to avoid public API timeouts
+const TXID_CHUNK_SIZE = REVENUE_SYNC.TXID_CHUNK_SIZE;
 
 /**
  * Fetch transaction IDs for an address within a block range using Flux daemon API.
@@ -526,7 +526,7 @@ export async function progressiveSync() {
     console.log('\nStarting BLOCK-RANGE SYNC...\n');
 
     const startTime = Date.now();
-    const BATCH_SIZE = 10;
+    const BATCH_SIZE = REVENUE_SYNC.APP_NAME_BATCH_SIZE;
 
     try {
         // 1. Sync historical price data (fast no-op if already current)
@@ -569,7 +569,7 @@ export async function progressiveSync() {
 
         let pendingPayments = [];   // buffer between DB flushes
         let totalNewPayments = 0;
-        const DB_FLUSH_SIZE = 200;  // write to DB every 200 payments so graphs update progressively
+        const DB_FLUSH_SIZE = REVENUE_SYNC.DB_FLUSH_SIZE;
         let syncAborted = false;
         let lowestFailedBlock = null;
 
@@ -752,7 +752,7 @@ export async function progressiveSync() {
 // DAILY AUDIT — catch missed transactions
 // ============================================
 
-const AUDIT_LOOKBACK_BLOCKS = 4320; // ~3 days of blocks
+const AUDIT_LOOKBACK_BLOCKS = REVENUE_SYNC.AUDIT_LOOKBACK_BLOCKS;
 
 /**
  * Audit recent transactions by re-fetching txids from the API and comparing against DB.
@@ -783,9 +783,9 @@ export async function auditRecentTransactions() {
             console.log(`Audit: checking ${txids.length} txids for ${address.substring(0, 15)}`);
 
             // Process transactions in small batches (dedup handled by ON CONFLICT DO NOTHING)
-            const BATCH_SIZE = 10;
-            for (let i = 0; i < txids.length; i += BATCH_SIZE) {
-                const batch = txids.slice(i, i + BATCH_SIZE);
+            const auditBatch = REVENUE_SYNC.AUDIT_BATCH_SIZE;
+            for (let i = 0; i < txids.length; i += auditBatch) {
+                const batch = txids.slice(i, i + auditBatch);
                 const txResults = await Promise.all(batch.map(txid => fetchRawTransaction(txid)));
                 const payments = [];
 


### PR DESCRIPTION
## Summary

Move all hardcoded magic numbers from service files into centralized config exports in `src/lib/config.js`. All tunable values now live in one file.

Closes #28

## New config sections

- **REVENUE_SYNC** — chunk size (50k), DB flush size (200), batch sizes (10), audit lookback (4320 blocks), price history batch (1000)
- **SNAPSHOT_CONFIG** — check interval (30min), grace period (5min), metric thresholds
- **BACKUP_CONFIG** — retention (30 days), retry count (3), backoff timing (1s/4s/16s)
- **CIRCUIT_BREAKER_CONFIG** — failure threshold (5), cooldown (60s)

## Files changed

- `src/lib/config.js` — added 4 new config sections
- `src/lib/services/revenueService.js` — 5 constants now imported from config
- `src/lib/services/priceHistoryService.js` — batch size from config
- `src/lib/services/backupService.js` — 3 constants from config
- `src/lib/db/snapshotManager.js` — 5 constants from config
- `src/lib/db/circuitBreaker.js` — 2 constants from config

## Test plan
- [x] `npm run test` — 79 tests pass (local + dev server)
- [x] API starts and returns healthy
- [x] Frontend loads correctly
- [x] Revenue sync runs with correct chunk sizes
- [x] Pure refactor — no behavior change, all values identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)