### PR TITLE
fix: Gaming/Crypto cards respond to timeframe toggle (D/W/M/Q/Y)

### DIFF
--- a/src/lib/components/CategoryCard.svelte
+++ b/src/lib/components/CategoryCard.svelte
@@ -6,6 +6,9 @@
   export let label = '';
   export let icon = null;
   export let loading = false;
+  export let period = 'D';
+
+  const periodDaysMap = { D: 1, W: 7, M: 30, Q: 90, Y: 365 };
 
   let API_URL = '';
   let repos = [];
@@ -14,6 +17,7 @@
   let previousRepos = [];
   let fetchError = false;
   let interval;
+  let mounted = false;
 
   function formatNumber(num) {
     if (!num) return '0';
@@ -31,7 +35,8 @@
   async function fetchCategoryData() {
     if (!API_URL || !category) return;
     try {
-      const response = await fetch(`${API_URL}/api/metrics/category/${category}/top?limit=3`);
+      const days = periodDaysMap[period] || 7;
+      const response = await fetch(`${API_URL}/api/metrics/category/${category}/top?limit=3&days=${days}`);
       if (!response.ok) throw new Error(`API error: ${response.status}`);
       const data = await response.json();
 
@@ -49,12 +54,18 @@
   onMount(() => {
     API_URL = getApiUrl();
     fetchCategoryData();
-    interval = setInterval(fetchCategoryData, 30 * 60 * 1000); // 30 min — data changes daily
+    interval = setInterval(fetchCategoryData, 30 * 60 * 1000);
+    mounted = true;
   });
 
   onDestroy(() => {
     if (interval) clearInterval(interval);
   });
+
+  // Re-fetch when period changes (after initial mount)
+  $: if (mounted && period) {
+    fetchCategoryData();
+  }
 
   $: totalComparison = getComparison(total, previousTotal);
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -391,10 +391,10 @@
     
     <div class="stats-grid-wide">
       <!-- Gaming Apps (Dynamic from repo_snapshots) -->
-      <CategoryCard category="gaming" label="Gaming App Instances" icon={Gamepad2} {loading} />
+      <CategoryCard category="gaming" label="Gaming App Instances" icon={Gamepad2} {loading} period={comparisonPeriod} />
 
       <!-- Crypto Nodes (Dynamic from repo_snapshots) -->
-      <CategoryCard category="crypto" label="Crypto Node Instances" icon={Coins} {loading} />
+      <CategoryCard category="crypto" label="Crypto Node Instances" icon={Coins} {loading} period={comparisonPeriod} />
       
       <!-- WordPress Sites -->
       <StatCard

--- a/src/server.js
+++ b/src/server.js
@@ -909,24 +909,25 @@ app.get('/api/history/repos/latest', async (req, res) => {
 app.get('/api/metrics/category/:category/top', async (req, res) => {
     const { category } = req.params;
     const limit = parseInt(req.query.limit) || 3;
+    const days = parseInt(req.query.days) || 7;
 
     if (!CATEGORY_CONFIG[category]) {
         return res.status(400).json({ error: `Unknown category: ${category}` });
     }
 
-    const cacheKey = `${category}:${limit}`;
+    const cacheKey = `${category}:${limit}:${days}`;
 
     return withDbFallback(categoryCache, cacheKey, res, async () => {
         const { date, repos } = await getTopReposByCategory(category, limit);
         if (!date) {
-            return { category, date: null, total: 0, previousTotal: 0, repos: [], previousRepos: [] };
+            return { category, date: null, total: 0, previousTotal: 0, repos: [], previousRepos: [], days };
         }
 
         const total = await getCategoryTotal(category, date);
 
-        // Get comparison data from 7 days ago
+        // Get comparison data from N days ago (based on query param)
         const prevDate = new Date(date);
-        prevDate.setDate(prevDate.getDate() - 7);
+        prevDate.setDate(prevDate.getDate() - days);
         const prevDateStr = prevDate.toISOString().split('T')[0];
         const previousTotal = await getCategoryTotal(category, prevDateStr);
 
@@ -935,7 +936,7 @@ app.get('/api/metrics/category/:category/top', async (req, res) => {
         for (const r of repos) {
             let prevRow = 0;
             try {
-                const history = await getRepoHistory(r.image_name, 90);
+                const history = await getRepoHistory(r.image_name, Math.max(days + 7, 90));
                 const match = history.find(h => h.snapshot_date === prevDateStr);
                 prevRow = match ? match.instance_count : 0;
             } catch { prevRow = 0; }
@@ -951,7 +952,8 @@ app.get('/api/metrics/category/:category/top', async (req, res) => {
                 ...r,
                 displayName: getDisplayName(r.image_name)
             })),
-            previousRepos
+            previousRepos,
+            days
         };
     });
 });


### PR DESCRIPTION
## Summary

The Gaming App Instances and Crypto Node Instances cards were hardcoded to compare against 7 days ago and did not respond to the D/W/M/Q/Y timeframe toggle. Now they update reactively like all other cards.

Fixes #35

## Changes

- **`src/server.js`** — `/api/metrics/category/:category/top` now accepts `?days=` query param (default 7 for backward compat). Cache key includes days to avoid stale data across periods.
- **`src/lib/components/CategoryCard.svelte`** — New `period` prop, maps D/W/M/Q/Y to days, re-fetches reactively when period changes.
- **`src/routes/+page.svelte`** — Passes `period={comparisonPeriod}` to both CategoryCard instances.

## Verified on dev server

| Timeframe | Gaming total | Gaming prev | Crypto total | Crypto prev |
|-----------|-------------|-------------|-------------|-------------|
| D (1 day) | 36 | 35 | 673 | 654 |
| W (7 days) | 36 | 33 | 673 | - |
| M (30 days) | 36 | 30 | 673 | 765 |
| Y (365 days) | 36 | 33 | 673 | - |

Different `previousTotal` values per timeframe confirms the fix works.

## Test plan
- [x] `npm run test` — 79 tests pass
- [x] API returns different comparison values per `?days=` param
- [x] Frontend: toggle D/W/M/Q/Y and Gaming/Crypto cards update
- [x] Other cards unaffected (Revenue, Cloud, Nodes, Apps still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)