### PR TITLE
fix: Bind Vite dev server to all interfaces for LAN access

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		host: '0.0.0.0'
+	}
 });


### PR DESCRIPTION
## Summary
- Vite 8 changed the default dev server host from `0.0.0.0` to `localhost`
- This blocks access from other machines on the network (e.g., accessing via `192.168.x.x`)
- Adds `server.host: '0.0.0.0'` to `vite.config.js` to restore LAN accessibility

Follow-up fix for PR #44 (dependency updates).

## Test plan
- [ ] `npm run dev:all` — frontend accessible from other machines on the network

🤖 Generated with [Claude Code](https://claude.com/claude-code)